### PR TITLE
Feature/autocomplete

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,4 +17,11 @@
 $gap: 32px;
 $fullhd: 1800px + (2 * $gap);
 
+.active {
+  z-index: 2;
+  color: #fff;
+  background-color: #485fc7;
+  border-color: #485fc7;
+}
+
 @import "bulma";

--- a/app/controllers/concerns/autocomplete.rb
+++ b/app/controllers/concerns/autocomplete.rb
@@ -1,0 +1,11 @@
+module Autocomplete
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_autocomplete_collection, only: :search
+
+    def search
+      render layout: false
+    end
+  end
+end

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -1,4 +1,5 @@
 class CustomersController < ApplicationController
+  include Autocomplete
   before_action :set_customer, only: %i[show edit update destroy]
 
   # GET /customers or /customers.json
@@ -69,5 +70,13 @@ class CustomersController < ApplicationController
     params.require(:customer).permit(
       :name, :email, :phone, :document, :avatar, :user_id, :birth_date, :gender,
       :street_address, :number, :complement, :district, :city, :state, :zip_code)
+  end
+
+  def set_autocomplete_collection
+    @autocomplete_collection = if params[:q]
+      Customer.find_by_name(params[:q])
+    else
+      Customer.all.order("name ASC").take(5)
+    end
   end
 end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,4 +1,5 @@
 class ServicesController < ApplicationController
+  include Autocomplete
   before_action :set_service, only: %i[show edit update destroy]
   before_action :set_services, only: %i[new create edit update]
   before_action :set_products, only: %i[new create edit update]
@@ -85,5 +86,13 @@ class ServicesController < ApplicationController
 
   def set_products
     @products ||= Product.all
+  end
+
+  def set_autocomplete_collection
+    @autocomplete_collection = if params[:q]
+      Service.find_by_title(params[:q])
+    else
+      Service.all.order("title ASC").take(5)
+    end
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,11 +1,4 @@
-// Import and register all your controllers from the importmap under controllers/*
-
 import { application } from "controllers/application"
+import { Autocomplete } from 'stimulus-autocomplete'
 
-// Eager load all controllers defined in the import map under controllers/**/*_controller
-import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
-eagerLoadControllersFrom("controllers", application)
-
-// Lazy load controllers as they appear in the DOM (remember not to preload controllers in import map!)
-// import { lazyLoadControllersFrom } from "@hotwired/stimulus-loading"
-// lazyLoadControllersFrom("controllers", application)
+application.register('autocomplete', Autocomplete)

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -18,6 +18,8 @@ class Customer < ApplicationRecord
   validates :district, length: { within: 1..100 }, if: -> { address_validation }
   validates :state, length: { within: 2..2 }, if: -> { address_validation }
 
+  scope :find_by_name, -> (query) { where("name ILIKE ?", "%#{query}%").select(:name, :id).order("name ASC").take(5) }
+
   def address_validation
     if street_address.present? ||
        number.present? ||

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -6,6 +6,8 @@ class Product < ApplicationRecord
 
   validates :name, :unit, presence: true
 
+  scope :query_by_name, -> (query) { where("name ILIKE ?", "%#{query}%") }
+
   def stock_balance
     stocks.reduce(0) { |sum, stock| sum + stock.balance_change }
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -16,6 +16,8 @@ class Service < ApplicationRecord
 
   accepts_nested_attributes_for :product_usages, allow_destroy: true, reject_if: :all_blank
 
+  scope :find_by_title, -> (query) { where("title ILIKE ?", "%#{query}%").select(:title, :id).order("title ASC").take(5) }
+
   def total_value
     price + optional_services&.sum(:price)
   end

--- a/app/views/bookings/_booking.html.erb
+++ b/app/views/bookings/_booking.html.erb
@@ -32,6 +32,10 @@
   </td>
 
   <td>
+    <%= booking.service.optional_services.count %>
+  </td>
+
+  <td>
     <%= link_to "Editar", edit_booking_path(booking), class: 'button is-small is-primary' %>
     <%= link_to "Deletar", booking, data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' }, class: "button is-danger is-small" %>
   </td>

--- a/app/views/bookings/_form.html.erb
+++ b/app/views/bookings/_form.html.erb
@@ -19,18 +19,26 @@
 
       <div class="field">
         <%= form.label 'Cliente', style: "display: block", class: "label" %>
-        <div class="control">
-          <div class="select is-fullwidth is-medium">
-            <%= form.collection_select :customer_id, Customer.all, :id, :name, { include_blank: 'selecione...', include_hidden: false } %>
+        <div class="is-fullwidth is-medium">
+          <div class="control">
+            <div data-controller="autocomplete" data-autocomplete-url-value="/customers/search">
+              <%= text_field_tag nil, {}, "data-autocomplete-target": "input", class: "input is-medium", placeholder: 'digite o nome do cliente...' %>
+              <ul class="list-group" data-autocomplete-target="results"></ul>
+              <input type="hidden" name="booking[customer_id]" data-autocomplete-target="hidden"/>
+            </div>
           </div>
         </div>
       </div>
 
       <div class="field">
         <%= form.label 'Serviço', style: "display: block", class: "label" %>
-        <div class="control">
-          <div class="select is-fullwidth is-medium">
-            <%= form.collection_select :service_id, Service.all, :id, :title, { include_blank: 'selecione...', include_hidden: false } %>
+        <div class="is-fullwidth is-medium">
+          <div class="control">
+            <div data-controller="autocomplete" data-autocomplete-url-value="/services/search">
+              <%= text_field_tag nil, {}, "data-autocomplete-target": "input", class: "input is-medium", placeholder: 'digite o nome do serviço...' %>
+              <ul class="list-group" data-autocomplete-target="results"></ul>
+              <input type="hidden" name="booking[service_id]" data-autocomplete-target="hidden"/>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/bookings/new.html.erb
+++ b/app/views/bookings/new.html.erb
@@ -1,3 +1,3 @@
 <h1 class="title is-size-3 mt-6 has-text-centered">Nova Reserva</h1>
 
-<%= render "form", booking: @booking %>
+<%= render "form", booking: @booking, customers: @customers %>

--- a/app/views/calendar/index.html.erb
+++ b/app/views/calendar/index.html.erb
@@ -1,3 +1,11 @@
+<div class="max-w-xs mx auto bg-white">
+
+  <div data-controller="autocomplete" data-autocomplete-url-value="/autocomplete">
+    <input type="text" class="w-full" data-autocomplete-target="input" placeholder="Type to search..."/>
+    <ul data-autocomplete-target="results"></ul>
+  </div>
+</div>
+
 <h1 class="mt-5 title has-text-centered">Calendários</h1>
 
 <div class="mt-6 has-text-centered">

--- a/app/views/customers/search.html.erb
+++ b/app/views/customers/search.html.erb
@@ -1,0 +1,5 @@
+<%= render 'shared/autocomplete',
+  collection: @autocomplete_collection,
+  autocomplete_value: :id,
+  autocomplete_label: :name
+%>

--- a/app/views/services/search.html.erb
+++ b/app/views/services/search.html.erb
@@ -1,0 +1,5 @@
+<%= render 'shared/autocomplete',
+  collection: @autocomplete_collection,
+  autocomplete_value: :id,
+  autocomplete_label: :title
+%>

--- a/app/views/shared/_autocomplete.html.erb
+++ b/app/views/shared/_autocomplete.html.erb
@@ -1,5 +1,5 @@
-<% @search_results.each do |result| %>
-  <li role="option" value="<% result.id %>"><%= result.name %></li>
+<% collection.each do |item| %>
+  <li class="list-group-item is-size-5 pl-3" role="option" data-autocomplete-value="<%= item.send(autocomplete_value) %>">
+    <%= item.send(autocomplete_label) %>
+  </li>
 <% end %>
-<!-- serviços -->
-<!-- customers -->

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -2,6 +2,8 @@
 
 pin "application", preload: true
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
-pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
+pin "stimulus-autocomplete", to: "https://ga.jspm.io/npm:stimulus-autocomplete@3.0.2/src/autocomplete.js"
+pin "@hotwired/stimulus", to: "https://ga.jspm.io/npm:@hotwired/stimulus@3.1.0/dist/stimulus.js"
+pin "js-autocomplete", to: "https://ga.jspm.io/npm:js-autocomplete@1.0.4/auto-complete.min.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,16 @@ Rails.application.routes.draw do
   resources :calendar, only: %i[index]
   resources :bookings
   resources :schedules
-  resources :services
+  resources :services do
+    collection do
+      get :search
+    end
+  end
   resources :professionals
   resources :customers do
+    collection do
+      get :search
+    end
     resources :anamnesis_sheets, except: %i[index edit]
     get '/bookings/in_progress', to: 'bookings#in_progress'
   end


### PR DESCRIPTION
Add the pin for the [stimulus-autocomplete](https://github.com/afcapel/stimulus-autocomplete)
Add the logic for the autocomplete in the `views/bookings/new` for the `services` and `customers`
Also included the `autocomplete.rb` to be more clean 

Fixed the `set_ends_at` in the booking model that was broking adding the { service.present? }
Fixed the views that was using `sum_duration` for `service.duration`

# screenshot
![Screenshot from 2022-08-26 17-52-35](https://user-images.githubusercontent.com/34282341/186990486-82a953e8-e03b-41e6-8197-091f4ae3b4ae.png)

